### PR TITLE
Create formal License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2015 Michael Auchter <a@phire.org>
+Copyright (c) 2018 Phil Frost (bitglue)
 Copyright (c) 2018 Mike Grant and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2015 Michael Auchter <a@phire.org>
+Copyright (c) 2018 Mike Grant and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Just to make it clearer for everyone, I'd like to surface a formal license for the project. As the original `haaska.py` has an MIT license in it, I believe we should use the same.

For the copyright, I've added a new entry that acknowledges @mike-grant and contributors.