### PR TITLE
Fixes permission issue for #22 in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ haaska.zip: haaska.py config/*
 	mkdir -p $(BUILD_DIR)
 	cp $^ $(BUILD_DIR)
 	pip install -t $(BUILD_DIR) requests
+	chmod 755 $(BUILD_DIR)/haaska.py
 	cd $(BUILD_DIR); zip ../$@ -r *
 
 .PHONY: deploy


### PR DESCRIPTION
Adds a line in the makefile that sets the correct permissions for haaska.py, but in the build directory. Since this directory is ignored in the .gitignore, there should be no pending changes as a result.