### PR TITLE
Fix usage of pip when non-root on Debian systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,16 @@ FUNCTION_NAME=haaska
 
 BUILD_DIR=build
 
+ifneq (,$(wildcard /etc/debian_version))
+        PIP_EXTRA = --system
+else
+        PIP_EXTRA =
+endif
+
 haaska.zip: haaska.py config/*
 	mkdir -p $(BUILD_DIR)
 	cp $^ $(BUILD_DIR)
-	pip install -t $(BUILD_DIR) requests
+	pip install $(PIP_EXTRA) -t $(BUILD_DIR) requests
 	chmod 755 $(BUILD_DIR)/haaska.py
 	cd $(BUILD_DIR); zip ../$@ -r *
 


### PR DESCRIPTION
pip defaults to user mode when non-root on Debian systems, causing an
error when building haaska.zip. Add --system to force system mode and
enable building as a regular user.