### PR TITLE
Add option for SSH Tunnel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ haaska.zip: haaska.py config/*
 	mkdir -p $(BUILD_DIR)
 	cp $^ $(BUILD_DIR)
 	pip install $(PIP_EXTRA) -t $(BUILD_DIR) requests
+	pip install $(PIP_EXTRA) -t $(BUILD_DIR) sshtunnel
 	chmod 755 $(BUILD_DIR)/haaska.py
-	cd $(BUILD_DIR); zip ../$@ -r *
+	if [ -e $(BUILD_DIR)/ssh.key ]; then chmod 755 $(BUILD_DIR)/ssh.key; fi
+	
+	cd $(BUILD_DIR); zip ../$@ -r .
 
 .PHONY: deploy
 deploy: haaska.zip

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -3,5 +3,13 @@
   "password": "",
   "debug": false,
   "ssl_verify": true,
-  "ssl_client": []
+  "ssl_client": [],
+  "ssh_enabled": false,
+  "ssh_username": "homeassistant",
+  "ssh_remote_host_public_url": "",
+  "ssh_remote_host_public_port": 22,
+  "ssh_remote_host_private_url": "",
+  "ssh_remote_host_private_port": 8123,
+  "ssh_local_host_port": 8123,
+  "ssh_key_is_encrypted": false
 }

--- a/haaska.py
+++ b/haaska.py
@@ -25,9 +25,11 @@ import os
 import json
 import logging
 import requests
+import boto3
+from sshtunnel import SSHTunnelForwarder
+from base64 import b64decode
 
 logger = logging.getLogger()
-
 
 class HomeAssistant(object):
     def __init__(self, config):
@@ -84,6 +86,15 @@ class Configuration(object):
         opts['password'] = self.get(['password', 'ha_passwd'], default='')
         opts['ssl_client'] = self.get(['ssl_client'], default='')
         opts['debug'] = self.get(['debug'], default=False)
+        opts['ssh_enabled'] = self.get(['ssh_enabled'], default=False)
+        if opts['ssh_enabled']:
+            opts['ssh_username'] = self.get(['ssh_username'], default='')
+            opts['ssh_remote_host_public_url'] = self.get(['ssh_remote_host_public_url'], default='')
+            opts['ssh_remote_host_public_port'] = self.get(['ssh_remote_host_public_port'], default=22)
+            opts['ssh_remote_host_private_url'] = self.get(['ssh_remote_host_private_url'], default='0.0.0.0')
+            opts['ssh_remote_host_private_port'] = self.get(['ssh_remote_host_private_port'], default=8123)
+            opts['ssh_local_host_port'] = self.get(['ssh_local_host_port'], default=8123)
+            opts['ssh_key_is_encrypted'] = self.get(['ssh_key_is_encrypted'], default=False)
         self.opts = opts
 
     def __getattr__(self, name):
@@ -98,11 +109,33 @@ class Configuration(object):
     def dump(self):
         return json.dumps(self.opts, indent=2, separators=(',', ': '))
 
+DECRYPTED_SSH_KEY_PASS = ""
+
+def get_decrypted_ssh_key_pass():
+    global DECRYPTED_SSH_KEY_PASS
+    if not DECRYPTED_SSH_KEY_PASS:
+        DECRYPTED_SSH_KEY_PASS = boto3.client('kms').decrypt(CiphertextBlob=b64decode(os.environ['ssh_key_pass']))['Plaintext']
+    return DECRYPTED_SSH_KEY_PASS
 
 def event_handler(event, context):
     config = Configuration('config.json')
     if config.debug:
         logger.setLevel(logging.DEBUG)
+    if config.ssh_enabled:
+        ssh_tunnel = SSHTunnelForwarder(
+            (config.ssh_remote_host_public, config.ssh_remote_host_public_port),
+            ssh_username=config.ssh_username,
+            ssh_pkey="./ssh.key",
+            ssh_private_key_password=get_decrypted_ssh_key_pass() if config.ssh_key_is_encrypted else os.environ['ssh_key_pass'],
+            remote_bind_address=(config.ssh_remote_host_private, config.ssh_remote_host_private_port),
+            local_bind_address=('0.0.0.0', config.ssh_local_host_port)
+        )
+        ssh_tunnel.start()
+        
     ha = HomeAssistant(config)
+    result = ha.post('alexa/smart_home', event, wait=True).json()
 
-    return ha.post('alexa/smart_home', event, wait=True).json()
+    if config.ssh_enabled:
+        ssh_tunnel.stop()
+
+    return result


### PR DESCRIPTION
Providing the option to use an SSHTunnel to contact Home Assistant instance.

Key based SSH access must be set up on a machine running Home Assistant. The relevant private key should be named **ssh.key** and copied to the config directory.  The SSH key password must be configured as an environment variable named **ssh_key_pass** on the lambda.  The config.json file needs to be updated to include the ssh parameters as specified in the config.json.sample.