### PR TITLE
Move to using Love Lived Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # haaska Changelog
 
+## [0.5] - 2018-09-18
+###
+- Breaking Change: Remove support for the legacy_auth provider in homeassistant
+- Implemented authentication using Long-Lived Access Tokens
+
 ## [0.4] - 2018-01-24
 ###
 - Changed code to work with Hass 0.62, please note this skill will break on any version older than this.

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8123/api",
-  "password": "",
+  "bearer_token": "",
   "debug": false,
   "ssl_verify": true,
   "ssl_client": []

--- a/haaska.py
+++ b/haaska.py
@@ -37,7 +37,7 @@ class HomeAssistant(object):
         agent_fmt = agent_str % (os.environ['AWS_DEFAULT_REGION'],
                                  requests.utils.default_user_agent())
         self.session = requests.Session()
-        self.session.headers = {'x-ha-access': config.password,
+        self.session.headers = {'Authorization': f'Bearer {config.bearer_token}',
                                 'content-type': 'application/json',
                                 'User-Agent': agent_fmt}
         self.session.verify = config.ssl_verify
@@ -81,7 +81,7 @@ class Configuration(object):
         opts['url'] = self.get(['url', 'ha_url'],
                                default='http://localhost:8123/api')
         opts['ssl_verify'] = self.get(['ssl_verify', 'ha_cert'], default=True)
-        opts['password'] = self.get(['password', 'ha_passwd'], default='')
+        opts['bearer_token'] = self.get(['bearer_token'], default='')
         opts['ssl_client'] = self.get(['ssl_client'], default='')
         opts['debug'] = self.get(['debug'], default=False)
         self.opts = opts

--- a/haaska.py
+++ b/haaska.py
@@ -37,7 +37,8 @@ class HomeAssistant(object):
         agent_fmt = agent_str % (os.environ['AWS_DEFAULT_REGION'],
                                  requests.utils.default_user_agent())
         self.session = requests.Session()
-        self.session.headers = {'Authorization': f'Bearer {config.bearer_token}',
+        self.session.headers = {'Authorization':
+                                f'Bearer {config.bearer_token}',
                                 'content-type': 'application/json',
                                 'User-Agent': agent_fmt}
         self.session.verify = config.ssl_verify


### PR DESCRIPTION
Allow users to move away from using the old authentication provider, and implement Long Live Tokens from HomeAssistant