### PR TITLE
Fix #75 and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.6"
 install:
-  - "pip install flake8"
+  - "pip install flake8 pytest"
+  - "pip install -r requirements.txt"
 script:
   - "flake8 haaska.py"
+  - "python -m pytest test.py"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # haaska: Home Assistant Alexa Skill Adapter
+
 [![Build Status](https://travis-ci.org/mike-grant/haaska.svg?branch=master)](https://travis-ci.org/mike-grant/haaska)
 
 ---
@@ -10,6 +11,13 @@ This provides voice control for a connected home managed by Home Assistant, thro
 ### Getting Started
 To get started, head over to the [haaska Wiki](https://github.com/mike-grant/haaska/wiki).
 
+### Development
+
+Run tests
+
+```
+python -m pytest test.py
+```
 
 ### Thanks and Acknowledgement
 
@@ -22,4 +30,4 @@ This fork of haaska was created by [@mike-grant](https://github.com/mike-grant).
 Documentation and additional maintenance is done by [@anthonylavado](https://github.com/anthonylavado), and contributors like you.
 
 ### License
-haaska is provided under the [MIT License](license.md).
+haaska is provided under the [MIT License](LICENSE).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest==4.0.2
+requests==2.21.0

--- a/test.py
+++ b/test.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+
+from haaska import HomeAssistant, Configuration
+
+@pytest.fixture
+def configuration():
+    return Configuration(opts_dict={
+        "url": "http://localhost:8123",
+        "bearer_token": "",
+        "debug": False,
+        "ssl_verify": True,
+        "ssl_client": []
+    })
+
+@pytest.fixture
+def home_assistant(configuration):
+    return HomeAssistant(configuration)
+
+def test_ha_build_url(home_assistant):
+    url = home_assistant.build_url("test")
+    assert url == "http://localhost:8123/api/test"
+
+def test_get_user_agent(home_assistant):
+    os.environ["AWS_DEFAULT_REGION"] = "test"
+    user_agent = home_assistant.get_user_agent()
+    assert user_agent.startswith("Home Assistant Alexa Smart Home Skill - test - python-requests/")
+
+def test_config_get(configuration):
+    assert configuration.get(["debug"]) == False
+    assert configuration.get(["test"]) == None
+    assert configuration.get(["test"], default="default") == "default"
+
+def test_config_get_url(configuration):
+    expected = "http://hass.example.com:8123"
+    assert configuration.get_url("http://hass.example.com:8123/") == expected
+    assert configuration.get_url("http://hass.example.com:8123/api") == expected
+    assert configuration.get_url("http://hass.example.com:8123/api/") == expected


### PR DESCRIPTION
I added better URL Handling (#75). You are now able use the following urls:
- http://hass.example.com:8123
- http://hass.example.com:8123/
- http://hass.example.com:8123/api
- http://hass.example.com:8123/api/

`Configuration` removes the endpoint `/api` and the trailing slash. The endpoint is added in `HomeAssistant.build_url` again.

Moreover I added tests to the project. You can run them with the following command:
```
python -m pytest test.py
```
I abstracted some functions to make them easier to test.