### PR TITLE
Correct url "/api" removal code

### DIFF
--- a/haaska.py
+++ b/haaska.py
@@ -99,7 +99,7 @@ class Configuration(object):
         if not url:
             raise ValueError('Property "url" is missing in config')
 
-        return url.rstrip("/api").rstrip("/")
+        return url.replace("/api", "").rstrip("/")
 
 
 def event_handler(event, context):

--- a/test.py
+++ b/test.py
@@ -32,7 +32,11 @@ def test_config_get(configuration):
     assert configuration.get(["test"], default="default") == "default"
 
 def test_config_get_url(configuration):
-    expected = "http://hass.example.com:8123"
-    assert configuration.get_url("http://hass.example.com:8123/") == expected
-    assert configuration.get_url("http://hass.example.com:8123/api") == expected
-    assert configuration.get_url("http://hass.example.com:8123/api/") == expected
+    test_urls = [
+        "http://hass.example.com:8123",
+        "http://hass.example.app:8123"
+    ]
+    for expected_url in test_urls:
+        assert configuration.get_url(expected_url + "/") == expected_url
+        assert configuration.get_url(expected_url + "/api") == expected_url
+        assert configuration.get_url(expected_url + "/api/") == expected_url

--- a/test.py
+++ b/test.py
@@ -34,7 +34,7 @@ def test_config_get(configuration):
 def test_config_get_url(configuration):
     test_urls = [
         "http://hass.example.com:8123",
-        "http://hass.example.app:8123"
+        "http://hass.example.app"
     ]
     for expected_url in test_urls:
         assert configuration.get_url(expected_url + "/") == expected_url


### PR DESCRIPTION
url.rstrip("/api") malforms urls with .app domains:

> url = "https://www.example.app"
> print("URL IS:", url)
_> URL IS: https://www.example.app_
print("URL IS:", url.rstrip("/api").rstrip("/"))
_> URL IS: https://www.example._

Using url.replace("/api", "") in its place followed by the stripping of trailing "/" corrects this behavior.