### PR TITLE
Update haaska.py

### DIFF
--- a/haaska.py
+++ b/haaska.py
@@ -99,7 +99,7 @@ class Configuration(object):
         if not url:
             raise ValueError('Property "url" is missing in config')
 
-        return url.replace("/api", "").rstrip("/")
+        return url.removesuffix("/api").removesuffix("/")
 
 
 def event_handler(event, context):


### PR DESCRIPTION
fix for remove correctly the end of the url, the original code for a domani like https://asd.casa/api return https://asd.cas