### PR TITLE
Cast ssl certs to a tuple to support requests > 2.31.0

### DIFF
--- a/haaska.py
+++ b/haaska.py
@@ -40,7 +40,7 @@ class HomeAssistant(object):
             'User-Agent': self.get_user_agent()
         }
         self.session.verify = config.ssl_verify
-        self.session.cert = config.ssl_client
+        self.session.cert = tuple(config.ssl_client)
 
     def build_url(self, endpoint):
         return f'{self.config.url}/api/{endpoint}'


### PR DESCRIPTION
The current code works fine for older requests versions, but to support > 2.31.0 they fixed a regression that allowed lists and tuples for ssl certs, to now only allow tuples: https://github.com/psf/requests/issues/6751